### PR TITLE
Refactor plugin for JTL Shop 5 compatibility

### DIFF
--- a/adminmenu/vehicle_search_settings.php
+++ b/adminmenu/vehicle_search_settings.php
@@ -1,70 +1,72 @@
 <?php
 
-/**
- * Vehicle Search Plugin Admin Settings for JTL Shop 5.x
- * 
- * @package Plugin\VehicleSearchPlugin\AdminMenu
- * @author Bremer Sitzbezüge
- * @version 1.0.0
- */
+declare(strict_types=1);
+
+use Plugin\VehicleSearchPlugin\Src\VehicleSearchPlugin;
+use JTL\Shop;
 
 require_once PFAD_ROOT . 'admin/includes/admininclude.php';
+
+$pluginHelper = Shop::Container()->getPluginHelper();
+$plugin = $pluginHelper->getPluginById(VehicleSearchPlugin::PLUGIN_ID);
+if ($plugin === null) {
+    die('Vehicle Search Plugin not available.');
+}
+
+$service = new VehicleSearchPlugin(
+    $plugin,
+    Shop::Container()->getDB(),
+    Shop::Container()->getCache()
+);
+
+$tokenSessionKey = 'vehicle_search_plugin_admin_csrf';
+if (empty($_SESSION[$tokenSessionKey]) || !is_string($_SESSION[$tokenSessionKey])) {
+    $_SESSION[$tokenSessionKey] = bin2hex(random_bytes(32));
+}
 
 $error = '';
 $success = '';
 
-// Handle form submission
-if ($_POST) {
-    try {
-        // Update configuration
-        $configs = [
-            'enable_ajax' => $_POST['enable_ajax'] ?? '0',
-            'default_search_type' => $_POST['default_search_type'] ?? 'M',
-            'max_results_per_page' => (int)($_POST['max_results_per_page'] ?? 20),
-            'enable_manufacturer_filter' => $_POST['enable_manufacturer_filter'] ?? '0',
-            'enable_model_filter' => $_POST['enable_model_filter'] ?? '0',
-            'enable_type_filter' => $_POST['enable_type_filter'] ?? '0',
-            'enable_category_filter' => $_POST['enable_category_filter'] ?? '0',
-            'cache_duration' => (int)($_POST['cache_duration'] ?? 3600),
-            'show_vehicle_images' => $_POST['show_vehicle_images'] ?? '0',
-            'enable_advanced_search' => $_POST['enable_advanced_search'] ?? '0'
-        ];
-        
-        foreach ($configs as $key => $value) {
-            $sql = "INSERT INTO tplugin_vehicle_search_config (cName, cValue) 
-                    VALUES (:key, :value) 
-                    ON DUPLICATE KEY UPDATE cValue = :value";
-            
-            Shop::DB()->executeQuery($sql, ['key' => $key, 'value' => $value]);
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $postedToken = (string)($_POST['csrf_token'] ?? '');
+    if (!hash_equals($_SESSION[$tokenSessionKey], $postedToken)) {
+        $error = 'Ungültiges Sicherheits-Token.';
+    } else {
+        if (isset($_POST['clear_cache'])) {
+            try {
+                $service->clearCache();
+                $success = 'Der Cache wurde geleert.';
+            } catch (Throwable $throwable) {
+                $error = 'Cache konnte nicht geleert werden: ' . $throwable->getMessage();
+            }
+        } else {
+            $configs = [
+                'enable_ajax' => isset($_POST['enable_ajax']) ? '1' : '0',
+                'default_search_type' => in_array($_POST['default_search_type'] ?? 'M', ['M', 'K'], true) ? $_POST['default_search_type'] : 'M',
+                'max_results_per_page' => max(1, (int)($_POST['max_results_per_page'] ?? 20)),
+                'enable_manufacturer_filter' => isset($_POST['enable_manufacturer_filter']) ? '1' : '0',
+                'enable_model_filter' => isset($_POST['enable_model_filter']) ? '1' : '0',
+                'enable_type_filter' => isset($_POST['enable_type_filter']) ? '1' : '0',
+                'enable_category_filter' => isset($_POST['enable_category_filter']) ? '1' : '0',
+                'cache_duration' => max(60, (int)($_POST['cache_duration'] ?? 3600)),
+                'show_vehicle_images' => isset($_POST['show_vehicle_images']) ? '1' : '0',
+                'enable_advanced_search' => isset($_POST['enable_advanced_search']) ? '1' : '0',
+            ];
+
+            try {
+                foreach ($configs as $key => $value) {
+                    $service->setConfig($key, $value);
+                }
+
+                $success = 'Einstellungen wurden gespeichert.';
+            } catch (Throwable $throwable) {
+                $error = 'Einstellungen konnten nicht gespeichert werden: ' . $throwable->getMessage();
+            }
         }
-        
-        $success = 'Settings saved successfully!';
-    } catch (Exception $e) {
-        $error = 'Error saving settings: ' . $e->getMessage();
     }
 }
 
-// Handle cache clear
-if (isset($_POST['clear_cache'])) {
-    try {
-        Shop::DB()->executeQuery("DELETE FROM tplugin_vehicle_search_cache WHERE dExpires < NOW()");
-        $success = 'Cache cleared successfully!';
-    } catch (Exception $e) {
-        $error = 'Error clearing cache: ' . $e->getMessage();
-    }
-}
-
-// Get current configuration
-$config = [];
-$sql = "SELECT cName, cValue FROM tplugin_vehicle_search_config";
-$result = Shop::DB()->executeQuery($sql);
-
-while ($row = $result->fetch()) {
-    $config[$row['cName']] = $row['cValue'];
-}
-
-// Set defaults
-$config = array_merge([
+$config = [
     'enable_ajax' => '1',
     'default_search_type' => 'M',
     'max_results_per_page' => '20',
@@ -74,12 +76,20 @@ $config = array_merge([
     'enable_category_filter' => '1',
     'cache_duration' => '3600',
     'show_vehicle_images' => '1',
-    'enable_advanced_search' => '1'
-], $config);
+    'enable_advanced_search' => '1',
+];
 
-$smarty = new Smarty();
+foreach (array_keys($config) as $key) {
+    $value = $service->getConfig($key, $config[$key]);
+    $config[$key] = is_string($value) ? $value : (string)$value;
+}
+
+$smarty = Shop::Smarty();
 $smarty->assign('config', $config);
 $smarty->assign('error', $error);
 $smarty->assign('success', $success);
+$smarty->assign('csrfToken', $_SESSION[$tokenSessionKey]);
+$smarty->assign('pluginUrl', $plugin->getPaths()->getBaseURL());
 
 echo $smarty->fetch('adminmenu/vehicle_search_settings.tpl');
+

--- a/adminmenu/vehicle_search_settings.tpl
+++ b/adminmenu/vehicle_search_settings.tpl
@@ -10,7 +10,7 @@
                         Vehicle Search Plugin Settings
                     </h3>
                 </div>
-                
+
                 <div class="card-body">
                     {if $error}
                         <div class="alert alert-danger">
@@ -18,19 +18,21 @@
                             {$error}
                         </div>
                     {/if}
-                    
+
                     {if $success}
                         <div class="alert alert-success">
                             <i class="fas fa-check-circle"></i>
                             {$success}
                         </div>
                     {/if}
-                    
+
                     <form method="POST" action="">
+                        <input type="hidden" name="csrf_token" value="{$csrfToken}" />
+
                         <div class="row">
                             <div class="col-md-6">
                                 <h5>General Settings</h5>
-                                
+
                                 <div class="form-group">
                                     <label for="enable_ajax">Enable AJAX</label>
                                     <select name="enable_ajax" id="enable_ajax" class="form-control">
@@ -39,90 +41,90 @@
                                     </select>
                                     <small class="form-text text-muted">Enable AJAX functionality for dynamic loading</small>
                                 </div>
-                                
+
                                 <div class="form-group">
                                     <label for="default_search_type">Default Search Type</label>
                                     <select name="default_search_type" id="default_search_type" class="form-control">
-                                        <option value="M" {if $config.default_search_type == 'M'}selected{/if}>Features (Merkmal)</option>
+                                        <option value="M" {if $config.default_search_type == 'M'}selected{/if}>Features (Merkmale)</option>
                                         <option value="K" {if $config.default_search_type == 'K'}selected{/if}>Categories</option>
                                     </select>
                                 </div>
-                                
+
                                 <div class="form-group">
                                     <label for="max_results_per_page">Max Results Per Page</label>
-                                    <input type="number" name="max_results_per_page" id="max_results_per_page" 
+                                    <input type="number" name="max_results_per_page" id="max_results_per_page"
                                            class="form-control" value="{$config.max_results_per_page}" min="1" max="100">
                                 </div>
-                                
+
                                 <div class="form-group">
                                     <label for="cache_duration">Cache Duration (seconds)</label>
-                                    <input type="number" name="cache_duration" id="cache_duration" 
+                                    <input type="number" name="cache_duration" id="cache_duration"
                                            class="form-control" value="{$config.cache_duration}" min="60" max="86400">
                                 </div>
                             </div>
-                            
+
                             <div class="col-md-6">
                                 <h5>Filter Settings</h5>
-                                
+
                                 <div class="form-group">
                                     <div class="form-check">
-                                        <input type="checkbox" name="enable_manufacturer_filter" id="enable_manufacturer_filter" 
-                                               class="form-check-input" value="1" 
+                                        <input type="checkbox" name="enable_manufacturer_filter" id="enable_manufacturer_filter"
+                                               class="form-check-input" value="1"
                                                {if $config.enable_manufacturer_filter == '1'}checked{/if}>
                                         <label class="form-check-label" for="enable_manufacturer_filter">
                                             Enable Manufacturer Filter
                                         </label>
                                     </div>
                                 </div>
-                                
+
                                 <div class="form-group">
                                     <div class="form-check">
-                                        <input type="checkbox" name="enable_model_filter" id="enable_model_filter" 
-                                               class="form-check-input" value="1" 
+                                        <input type="checkbox" name="enable_model_filter" id="enable_model_filter"
+                                               class="form-check-input" value="1"
                                                {if $config.enable_model_filter == '1'}checked{/if}>
                                         <label class="form-check-label" for="enable_model_filter">
                                             Enable Model Filter
                                         </label>
                                     </div>
                                 </div>
-                                
+
                                 <div class="form-group">
                                     <div class="form-check">
-                                        <input type="checkbox" name="enable_type_filter" id="enable_type_filter" 
-                                               class="form-check-input" value="1" 
+                                        <input type="checkbox" name="enable_type_filter" id="enable_type_filter"
+                                               class="form-check-input" value="1"
                                                {if $config.enable_type_filter == '1'}checked{/if}>
                                         <label class="form-check-label" for="enable_type_filter">
                                             Enable Vehicle Type Filter
                                         </label>
                                     </div>
                                 </div>
-                                
+
                                 <div class="form-group">
                                     <div class="form-check">
-                                        <input type="checkbox" name="enable_category_filter" id="enable_category_filter" 
-                                               class="form-check-input" value="1" 
+                                        <input type="checkbox" name="enable_category_filter" id="enable_category_filter"
+                                               class="form-check-input" value="1"
                                                {if $config.enable_category_filter == '1'}checked{/if}>
                                         <label class="form-check-label" for="enable_category_filter">
                                             Enable Category Filter
                                         </label>
                                     </div>
                                 </div>
-                                
+
                                 <div class="form-group">
                                     <div class="form-check">
-                                        <input type="checkbox" name="show_vehicle_images" id="show_vehicle_images" 
-                                               class="form-check-input" value="1" 
+                                        <input type="checkbox" name="show_vehicle_images" id="show_vehicle_images"
+                                               class="form-check-input" value="1"
                                                {if $config.show_vehicle_images == '1'}checked{/if}>
                                         <label class="form-check-label" for="show_vehicle_images">
                                             Show Vehicle Images
                                         </label>
                                     </div>
                                 </div>
-                                
+
                                 <div class="form-group">
                                     <div class="form-check">
-                                        <input type="checkbox" name="enable_advanced_search" id="enable_advanced_search" 
-                                               class="form-check-input" value="1" 
+                                        <input type="checkbox" name="enable_advanced_search" id="enable_advanced_search"
+                                               class="form-check-input" value="1"
                                                {if $config.enable_advanced_search == '1'}checked{/if}>
                                         <label class="form-check-label" for="enable_advanced_search">
                                             Enable Advanced Search
@@ -131,23 +133,18 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                         <div class="row mt-4">
                             <div class="col-12">
                                 <button type="submit" class="btn btn-primary">
                                     <i class="fas fa-save"></i>
                                     Save Settings
                                 </button>
-                                
-                                <a href="{$pluginUrl}adminmenu/clear_cache.php" class="btn btn-warning ml-2">
+
+                                <button type="submit" name="clear_cache" value="1" class="btn btn-warning ml-2">
                                     <i class="fas fa-trash"></i>
                                     Clear Cache
-                                </a>
-                                
-                                <a href="{$pluginUrl}adminmenu/statistics.php" class="btn btn-info ml-2">
-                                    <i class="fas fa-chart-bar"></i>
-                                    View Statistics
-                                </a>
+                                </button>
                             </div>
                         </div>
                     </form>
@@ -156,3 +153,4 @@
         </div>
     </div>
 </div>
+

--- a/frontend/ajax.php
+++ b/frontend/ajax.php
@@ -1,219 +1,125 @@
 <?php
 
-/**
- * Vehicle Search Plugin AJAX Endpoint for JTL Shop 5.x
- * 
- * @package Plugin\VehicleSearchPlugin\Frontend
- * @author Bremer Sitzbezüge
- * @version 1.0.0
- */
+declare(strict_types=1);
+
+use JTL\Shop;
+use Plugin\VehicleSearchPlugin\Src\VehicleSearchPlugin;
 
 require_once PFAD_ROOT . 'includes/globalinclude.php';
 
-// Set JSON header
-header('Content-Type: application/json');
+header('Content-Type: application/json; charset=utf-8');
 
-// Check if request is AJAX
-if (!isset($_SERVER['HTTP_X_REQUESTED_WITH']) || 
-    strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) !== 'xmlhttprequest') {
-    http_response_code(400);
-    echo json_encode(['success' => false, 'error' => 'Invalid request']);
+if (strcasecmp($_SERVER['REQUEST_METHOD'] ?? 'GET', 'POST') !== 0) {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
     exit;
 }
 
-// Check CSRF token
-$csrfToken = $_POST['csrf_token'] ?? '';
-if (!hash_equals($_SESSION['csrf_token'] ?? '', $csrfToken)) {
+if (!isAjaxRequest()) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Invalid request type']);
+    exit;
+}
+
+$csrfToken = (string)($_POST['csrf_token'] ?? '');
+$sessionToken = (string)($_SESSION['vehicle_search_plugin_csrf'] ?? '');
+if ($sessionToken === '' || !hash_equals($sessionToken, $csrfToken)) {
     http_response_code(403);
     echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
     exit;
 }
 
-// Get action
-$action = $_POST['action'] ?? '';
+$pluginHelper = Shop::Container()->getPluginHelper();
+$plugin = $pluginHelper->getPluginById(VehicleSearchPlugin::PLUGIN_ID);
+if ($plugin === null) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Plugin context unavailable']);
+    exit;
+}
+
+$service = new VehicleSearchPlugin(
+    $plugin,
+    Shop::Container()->getDB(),
+    Shop::Container()->getCache()
+);
+
+$action = trim((string)($_POST['action'] ?? ''));
 
 try {
     switch ($action) {
         case 'getManufacturers':
-            $manufacturers = getManufacturers();
-            echo json_encode(['success' => true, 'manufacturers' => $manufacturers]);
+            respond(['manufacturers' => $service->getManufacturers()]);
             break;
-            
+
         case 'getVehicleModels':
-            $manufacturerId = (int)($_POST['manufacturer_id'] ?? 0);
-            if ($manufacturerId <= 0) {
-                throw new Exception('Invalid manufacturer ID');
+            $manufacturerId = filter_input(INPUT_POST, 'manufacturer_id', FILTER_VALIDATE_INT);
+            if ($manufacturerId === false || $manufacturerId <= 0) {
+                throw new InvalidArgumentException('Invalid manufacturer identifier');
             }
-            
-            $models = getVehicleModelsByManufacturer($manufacturerId);
-            echo json_encode(['success' => true, 'models' => $models]);
+
+            respond(['models' => $service->getVehicleModelsByManufacturer($manufacturerId)]);
             break;
-            
+
         case 'getVehicleTypes':
-            $modelName = trim($_POST['model_name'] ?? '');
-            if (empty($modelName)) {
-                throw new Exception('Invalid model name');
+            $modelName = filter_input(INPUT_POST, 'model_name', FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH);
+            $modelName = is_string($modelName) ? trim($modelName) : '';
+            if ($modelName === '') {
+                throw new InvalidArgumentException('Invalid model name');
             }
-            
-            $types = getVehicleTypesByModel($modelName);
-            echo json_encode(['success' => true, 'types' => $types]);
+
+            respond(['types' => $service->getVehicleTypesByModel($modelName)]);
             break;
-            
+
         case 'getCategories':
-            $categories = getCategories();
-            echo json_encode(['success' => true, 'categories' => $categories]);
+            respond(['categories' => $service->getCategories()]);
             break;
-            
+
         case 'logSearch':
             $searchData = [
-                'search_type' => $_POST['search_type'] ?? '',
-                'manufacturer' => $_POST['manufacturer'] ?? null,
-                'model' => $_POST['model'] ?? null,
-                'vehicle_type' => $_POST['vehicle_type'] ?? null,
-                'category' => $_POST['category'] ?? null,
-                'results' => (int)($_POST['results'] ?? 0)
+                'searchType' => sanitizeString($_POST['search_type'] ?? ''),
+                'manufacturer' => sanitizeString($_POST['manufacturer'] ?? null),
+                'model' => sanitizeString($_POST['model'] ?? null),
+                'vehicleType' => sanitizeString($_POST['vehicle_type'] ?? null),
+                'category' => sanitizeString($_POST['category'] ?? null),
+                'results' => filter_input(INPUT_POST, 'results', FILTER_VALIDATE_INT) ?: 0,
             ];
-            
-            logSearchStats($searchData);
-            echo json_encode(['success' => true]);
+
+            $service->logSearchStats($searchData);
+            respond();
             break;
-            
+
         default:
-            throw new Exception('Invalid action');
+            throw new InvalidArgumentException('Unknown action');
     }
-} catch (Exception $e) {
+} catch (InvalidArgumentException $exception) {
     http_response_code(400);
-    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+    echo json_encode(['success' => false, 'error' => $exception->getMessage()]);
+} catch (Throwable $throwable) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Unexpected error']);
 }
 
-/**
- * Get manufacturers from database
- */
-function getManufacturers() {
-    $sql = "SELECT h.kHersteller, h.cName, h.cBildpfad
-            FROM thersteller h
-            INNER JOIN tartikel a ON h.kHersteller = a.kHersteller
-            WHERE h.nAktiv = 1 
-            AND a.nAktiv = 1
-            GROUP BY h.kHersteller, h.cName, h.cBildpfad
-            ORDER BY h.cName ASC";
-    
-    $result = Shop::DB()->executeQuery($sql);
-    $manufacturers = [];
-    
-    while ($row = $result->fetch()) {
-        $manufacturers[] = [
-            'value' => $row['kHersteller'],
-            'text' => $row['cName'],
-            'image' => $row['cBildpfad']
-        ];
+function respond(array $payload = []): void
+{
+    echo json_encode(['success' => true] + $payload);
+    exit;
+}
+
+function sanitizeString($value): ?string
+{
+    if ($value === null) {
+        return null;
     }
-    
-    return $manufacturers;
+
+    $value = trim((string) $value);
+
+    return $value === '' ? null : $value;
 }
 
-/**
- * Get vehicle models by manufacturer
- */
-function getVehicleModelsByManufacturer($manufacturerId) {
-    $sql = "SELECT DISTINCT mw.kMerkmalwert, mw.cWert
-            FROM tmerkmalwert mw
-            INNER JOIN tartikelmerkmal am ON mw.kMerkmalwert = am.kMerkmalwert
-            INNER JOIN tartikel a ON am.kArtikel = a.kArtikel
-            INNER JOIN thersteller h ON a.kHersteller = h.kHersteller
-            WHERE h.kHersteller = :manufacturerId 
-            AND mw.kMerkmal = 250
-            AND mw.cWert IS NOT NULL 
-            AND mw.cWert != '' 
-            AND a.nAktiv = 1
-            ORDER BY mw.cWert ASC";
-    
-    $result = Shop::DB()->executeQuery($sql, ['manufacturerId' => $manufacturerId]);
-    $models = [];
-    
-    while ($row = $result->fetch()) {
-        $models[] = [
-            'value' => $row['cWert'],
-            'text' => $row['cWert']
-        ];
-    }
-    
-    return $models;
+function isAjaxRequest(): bool
+{
+    $requestedWith = $_SERVER['HTTP_X_REQUESTED_WITH'] ?? '';
+
+    return is_string($requestedWith) && strcasecmp($requestedWith, 'XMLHttpRequest') === 0;
 }
 
-/**
- * Get vehicle types by model
- */
-function getVehicleTypesByModel($modelName) {
-    $sql = "SELECT DISTINCT mw.kMerkmalwert, mw.cWert
-            FROM tmerkmalwert mw
-            INNER JOIN tartikelmerkmal am ON mw.kMerkmalwert = am.kMerkmalwert
-            INNER JOIN tartikel a ON am.kArtikel = a.kArtikel
-            WHERE mw.kMerkmal = 252
-            AND mw.cWert LIKE :modelName
-            AND mw.cWert IS NOT NULL 
-            AND mw.cWert != '' 
-            AND a.nAktiv = 1
-            ORDER BY mw.cWert ASC";
-    
-    $result = Shop::DB()->executeQuery($sql, ['modelName' => '%' . $modelName . '%']);
-    $types = [];
-    
-    while ($row = $result->fetch()) {
-        $types[] = [
-            'value' => $row['cWert'],
-            'text' => $row['cWert']
-        ];
-    }
-    
-    return $types;
-}
-
-/**
- * Get categories
- */
-function getCategories() {
-    $sql = "SELECT k.kKategorie, k.cName, k.cBeschreibung, k.nSort, k.kOberKategorie
-            FROM tkategorie k
-            INNER JOIN tkategorieartikel ka ON k.kKategorie = ka.kKategorie
-            INNER JOIN tartikel a ON ka.kArtikel = a.kArtikel
-            WHERE k.nAktiv = 1 
-            AND a.nAktiv = 1
-            GROUP BY k.kKategorie, k.cName, k.cBeschreibung, k.nSort, k.kOberKategorie
-            ORDER BY k.nSort ASC, k.cName ASC";
-    
-    $result = Shop::DB()->executeQuery($sql);
-    $categories = [];
-    
-    while ($row = $result->fetch()) {
-        $categories[] = [
-            'value' => $row['kKategorie'],
-            'text' => $row['cName'],
-            'description' => $row['cBeschreibung'],
-            'parent' => $row['kOberKategorie'],
-            'sort' => $row['nSort']
-        ];
-    }
-    
-    return $categories;
-}
-
-/**
- * Log search statistics
- */
-function logSearchStats($searchData) {
-    $sql = "INSERT INTO tplugin_vehicle_search_stats 
-            (cSearchType, cManufacturer, cModel, cVehicleType, kKategorie, nResults, cIP, cUserAgent) 
-            VALUES (:searchType, :manufacturer, :model, :vehicleType, :category, :results, :ip, :userAgent)";
-    
-    Shop::DB()->executeQuery($sql, [
-        'searchType' => $searchData['search_type'] ?? '',
-        'manufacturer' => $searchData['manufacturer'] ?? null,
-        'model' => $searchData['model'] ?? null,
-        'vehicleType' => $searchData['vehicle_type'] ?? null,
-        'category' => $searchData['category'] ?? null,
-        'results' => $searchData['results'] ?? 0,
-        'ip' => $_SERVER['REMOTE_ADDR'] ?? '',
-        'userAgent' => $_SERVER['HTTP_USER_AGENT'] ?? ''
-    ]);
-}

--- a/frontend/hooks/footer.php
+++ b/frontend/hooks/footer.php
@@ -1,25 +1,35 @@
 <?php
 
-namespace Plugin\VehicleSearchPlugin\Frontend\Hooks;
+declare(strict_types=1);
 
-use JTL\Plugin\Hook\HookInterface;
+use JTL\Plugin\PluginInterface;
+use JTL\Shop;
 
-/**
- * Class Footer
- * @package Plugin\VehicleSearchPlugin\Frontend\Hooks
- */
-class Footer implements HookInterface
-{
-    /**
-     * @inheritdoc
-     */
-    public function execute(array $args): void
-    {
-        // Add JavaScript resources to footer
-        $plugin = $this->getPlugin();
-        if ($plugin) {
-            $pluginUrl = $plugin->getPaths()->getFrontendPath();
-            echo '<script src="' . $pluginUrl . 'js/vehicle-search.js" type="text/javascript"></script>';
-        }
-    }
+/** @var array<string, mixed> $args */
+$plugin = $args['plugin'] ?? null;
+if (!$plugin instanceof PluginInterface) {
+    $plugin = Shop::Container()->getPluginHelper()->getPluginById('VehicleSearchPlugin');
 }
+
+if ($plugin === null) {
+    return;
+}
+
+$sessionKey = 'vehicle_search_plugin_csrf';
+if (empty($_SESSION[$sessionKey]) || !is_string($_SESSION[$sessionKey])) {
+    $_SESSION[$sessionKey] = bin2hex(random_bytes(32));
+}
+
+$frontendPath = $plugin->getPaths()->getFrontendPath();
+$config = [
+    'pluginUrl' => $frontendPath,
+    'csrfToken' => $_SESSION[$sessionKey],
+];
+
+echo '<script type="text/javascript">';
+echo 'window.VehicleSearchPlugin = Object.assign({}, window.VehicleSearchPlugin || {}, ';
+echo json_encode($config, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+echo ');';
+echo '</script>';
+echo '<script src="' . htmlspecialchars($frontendPath . 'js/vehicle-search.js', ENT_QUOTES, 'UTF-8') . '" type="text/javascript"></script>';
+

--- a/frontend/hooks/header.php
+++ b/frontend/hooks/header.php
@@ -1,25 +1,22 @@
 <?php
 
-namespace Plugin\VehicleSearchPlugin\Frontend\Hooks;
+declare(strict_types=1);
 
-use JTL\Plugin\Hook\HookInterface;
+use JTL\Shop;
+use JTL\Plugin\PluginInterface;
 
-/**
- * Class Header
- * @package Plugin\VehicleSearchPlugin\Frontend\Hooks
- */
-class Header implements HookInterface
-{
-    /**
-     * @inheritdoc
-     */
-    public function execute(array $args): void
-    {
-        // Add CSS and JS resources to header
-        $plugin = $this->getPlugin();
-        if ($plugin) {
-            $pluginUrl = $plugin->getPaths()->getFrontendPath();
-            echo '<link rel="stylesheet" href="' . $pluginUrl . 'css/vehicle-search.css" type="text/css" />';
-        }
-    }
+/** @var array<string, mixed> $args */
+$plugin = $args['plugin'] ?? null;
+if (!$plugin instanceof PluginInterface) {
+    $plugin = Shop::Container()->getPluginHelper()->getPluginById('VehicleSearchPlugin');
 }
+
+if ($plugin === null) {
+    return;
+}
+
+$path = $plugin->getPaths()->getFrontendPath();
+$stylesheet = $path . 'css/vehicle-search.css';
+
+echo '<link rel="stylesheet" type="text/css" href="' . htmlspecialchars($stylesheet, ENT_QUOTES, 'UTF-8') . '" />';
+

--- a/info.xml
+++ b/info.xml
@@ -5,7 +5,9 @@
     <Author>Bremer Sitzbezüge</Author>
     <URL>https://bremer-sitzbezuege.de</URL>
     <XMLVersion>100</XMLVersion>
-    <ShopVersion>500</ShopVersion>
+    <MinShopVersion>500</MinShopVersion>
+    <MaxShopVersion>599</MaxShopVersion>
+    <MinPHPVersion>7.4</MinPHPVersion>
     <PluginID>VehicleSearchPlugin</PluginID>
     <Version>1.0.0</Version>
     <CreateDate>2025-01-10</CreateDate>

--- a/src/VehicleSearchPlugin.php
+++ b/src/VehicleSearchPlugin.php
@@ -1,324 +1,367 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Plugin\VehicleSearchPlugin\Src;
 
+use JTL\Cache\JTLCacheInterface;
 use JTL\Plugin\PluginInterface;
 use JTL\DB\DbInterface;
-use JTL\Cache\JTLCacheInterface;
-use JTL\Smarty\JTLSmarty;
-use Exception;
+use PDO;
+use PDOStatement;
 
 /**
- * Vehicle Search Plugin for JTL Shop 5.x
- * 
- * @package Plugin\VehicleSearchPlugin\Src
- * @author Bremer Sitzbezüge
- * @version 1.0.0
+ * Vehicle Search Plugin data/service layer.
  */
 class VehicleSearchPlugin
 {
+    public const PLUGIN_ID = 'VehicleSearchPlugin';
+
+    public const VERSION = '1.0.0';
+
+    private const CACHE_TAG = 'vehicle_search_plugin';
+
+    private PluginInterface $plugin;
+
+    private DbInterface $db;
+
+    private JTLCacheInterface $cache;
+
     /**
-     * Plugin ID
+     * @var array<string, mixed>
      */
-    const PLUGIN_ID = 'VehicleSearchPlugin';
-    
-    /**
-     * Plugin version
-     */
-    const VERSION = '1.0.0';
-    
-    /**
-     * @var PluginInterface
-     */
-    private $plugin;
-    
-    /**
-     * @var DbInterface
-     */
-    private $db;
-    
-    /**
-     * @var JTLCacheInterface
-     */
-    private $cache;
-    
-    /**
-     * Configuration cache
-     */
-    private static $configCache = [];
-    
-    /**
-     * Constructor
-     * 
-     * @param PluginInterface $plugin
-     * @param DbInterface $db
-     * @param JTLCacheInterface $cache
-     */
+    private array $configCache = [];
+
     public function __construct(PluginInterface $plugin, DbInterface $db, JTLCacheInterface $cache)
     {
         $this->plugin = $plugin;
         $this->db = $db;
         $this->cache = $cache;
     }
-    
+
     /**
-     * Get manufacturers from database
-     * 
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     public function getManufacturers(): array
     {
-        $cacheKey = 'manufacturers_' . md5('all');
+        $cacheKey = $this->cacheKey('manufacturers');
         $cached = $this->cache->get($cacheKey);
-        if ($cached !== false) {
+        if (is_array($cached)) {
             return $cached;
         }
-        
-        $sql = "SELECT h.kHersteller, h.cName, h.cBildpfad
-                FROM thersteller h
-                INNER JOIN tartikel a ON h.kHersteller = a.kHersteller
-                WHERE h.nAktiv = 1 
-                AND a.nAktiv = 1
-                GROUP BY h.kHersteller, h.cName, h.cBildpfad
-                ORDER BY h.cName ASC";
-        
-        $result = $this->db->executeQuery($sql);
-        $manufacturers = [];
-        
-        while ($row = $result->fetch()) {
-            $manufacturers[] = [
-                'value' => $row['kHersteller'],
-                'text' => $row['cName'],
-                'image' => $row['cBildpfad']
+
+        $sql = <<<'SQL'
+            SELECT h.kHersteller,
+                   h.cName,
+                   h.cBildpfad
+              FROM thersteller h
+              INNER JOIN tartikel a ON h.kHersteller = a.kHersteller
+             WHERE h.nAktiv = 1
+               AND a.nAktiv = 1
+          GROUP BY h.kHersteller, h.cName, h.cBildpfad
+          ORDER BY h.cName ASC
+        SQL;
+
+        $rows = $this->fetchAll($sql);
+        $manufacturers = array_map(static function (array $row): array {
+            return [
+                'value' => (int) $row['kHersteller'],
+                'text' => (string) $row['cName'],
+                'image' => $row['cBildpfad'] ?? '',
             ];
-        }
-        
-        $this->cache->set($cacheKey, $manufacturers, 3600);
+        }, $rows);
+
+        $this->cache->set($cacheKey, $manufacturers, [self::CACHE_TAG], $this->getCacheLifetime());
+
         return $manufacturers;
     }
-    
+
     /**
-     * Get vehicle models by manufacturer
-     * 
-     * @param int $manufacturerId
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     public function getVehicleModelsByManufacturer(int $manufacturerId): array
     {
-        $cacheKey = 'models_' . $manufacturerId;
+        $cacheKey = $this->cacheKey('models_' . $manufacturerId);
         $cached = $this->cache->get($cacheKey);
-        if ($cached !== false) {
+        if (is_array($cached)) {
             return $cached;
         }
-        
-        $sql = "SELECT DISTINCT mw.kMerkmalwert, mw.cWert
-                FROM tmerkmalwert mw
-                INNER JOIN tartikelmerkmal am ON mw.kMerkmalwert = am.kMerkmalwert
-                INNER JOIN tartikel a ON am.kArtikel = a.kArtikel
-                INNER JOIN thersteller h ON a.kHersteller = h.kHersteller
-                WHERE h.kHersteller = :manufacturerId 
-                AND mw.kMerkmal = 250
-                AND mw.cWert IS NOT NULL 
-                AND mw.cWert != '' 
-                AND a.nAktiv = 1
-                ORDER BY mw.cWert ASC";
-        
-        $result = $this->db->executeQuery($sql, ['manufacturerId' => $manufacturerId]);
-        $models = [];
-        
-        while ($row = $result->fetch()) {
-            $models[] = [
-                'value' => $row['cWert'],
-                'text' => $row['cWert']
+
+        $sql = <<<'SQL'
+            SELECT DISTINCT mw.kMerkmalwert,
+                            mw.cWert
+              FROM tmerkmalwert mw
+              INNER JOIN tartikelmerkmal am ON mw.kMerkmalwert = am.kMerkmalwert
+              INNER JOIN tartikel a ON am.kArtikel = a.kArtikel
+              INNER JOIN thersteller h ON a.kHersteller = h.kHersteller
+             WHERE h.kHersteller = :manufacturerId
+               AND mw.kMerkmal = 250
+               AND mw.cWert IS NOT NULL
+               AND mw.cWert != ''
+               AND a.nAktiv = 1
+          ORDER BY mw.cWert ASC
+        SQL;
+
+        $rows = $this->fetchAll($sql, ['manufacturerId' => $manufacturerId]);
+        $models = array_map(static function (array $row): array {
+            $value = (string) $row['cWert'];
+
+            return [
+                'value' => $value,
+                'text' => $value,
             ];
-        }
-        
-        $this->cache->set($cacheKey, $models, 1800);
+        }, $rows);
+
+        $this->cache->set($cacheKey, $models, [self::CACHE_TAG], $this->getCacheLifetime(1800));
+
         return $models;
     }
-    
+
     /**
-     * Get vehicle types by model
-     * 
-     * @param string $modelName
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     public function getVehicleTypesByModel(string $modelName): array
     {
-        $cacheKey = 'types_' . md5($modelName);
+        $modelName = trim($modelName);
+        if ($modelName === '') {
+            return [];
+        }
+
+        $cacheKey = $this->cacheKey('types_' . md5($modelName));
         $cached = $this->cache->get($cacheKey);
-        if ($cached !== false) {
+        if (is_array($cached)) {
             return $cached;
         }
-        
-        $sql = "SELECT DISTINCT mw.kMerkmalwert, mw.cWert
-                FROM tmerkmalwert mw
-                INNER JOIN tartikelmerkmal am ON mw.kMerkmalwert = am.kMerkmalwert
-                INNER JOIN tartikel a ON am.kArtikel = a.kArtikel
-                WHERE mw.kMerkmal = 252
-                AND mw.cWert LIKE :modelName
-                AND mw.cWert IS NOT NULL 
-                AND mw.cWert != '' 
-                AND a.nAktiv = 1
-                ORDER BY mw.cWert ASC";
-        
-        $result = $this->db->executeQuery($sql, ['modelName' => '%' . $modelName . '%']);
-        $types = [];
-        
-        while ($row = $result->fetch()) {
-            $types[] = [
-                'value' => $row['cWert'],
-                'text' => $row['cWert']
+
+        $sql = <<<'SQL'
+            SELECT DISTINCT mw.kMerkmalwert,
+                            mw.cWert
+              FROM tmerkmalwert mw
+              INNER JOIN tartikelmerkmal am ON mw.kMerkmalwert = am.kMerkmalwert
+              INNER JOIN tartikel a ON am.kArtikel = a.kArtikel
+             WHERE mw.kMerkmal = 252
+               AND mw.cWert LIKE :modelName
+               AND mw.cWert IS NOT NULL
+               AND mw.cWert != ''
+               AND a.nAktiv = 1
+          ORDER BY mw.cWert ASC
+        SQL;
+
+        $rows = $this->fetchAll($sql, ['modelName' => '%' . $modelName . '%']);
+        $types = array_map(static function (array $row): array {
+            $value = (string) $row['cWert'];
+
+            return [
+                'value' => $value,
+                'text' => $value,
             ];
-        }
-        
-        $this->cache->set($cacheKey, $types, 1800);
+        }, $rows);
+
+        $this->cache->set($cacheKey, $types, [self::CACHE_TAG], $this->getCacheLifetime(1800));
+
         return $types;
     }
-    
+
     /**
-     * Get categories
-     * 
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     public function getCategories(): array
     {
-        $cacheKey = 'categories_all';
+        $cacheKey = $this->cacheKey('categories_all');
         $cached = $this->cache->get($cacheKey);
-        if ($cached !== false) {
+        if (is_array($cached)) {
             return $cached;
         }
-        
-        $sql = "SELECT k.kKategorie, k.cName, k.cBeschreibung, k.nSort, k.kOberKategorie
-                FROM tkategorie k
-                INNER JOIN tkategorieartikel ka ON k.kKategorie = ka.kKategorie
-                INNER JOIN tartikel a ON ka.kArtikel = a.kArtikel
-                WHERE k.nAktiv = 1 
-                AND a.nAktiv = 1
-                GROUP BY k.kKategorie, k.cName, k.cBeschreibung, k.nSort, k.kOberKategorie
-                ORDER BY k.nSort ASC, k.cName ASC";
-        
-        $result = $this->db->executeQuery($sql);
-        $categories = [];
-        
-        while ($row = $result->fetch()) {
-            $categories[] = [
-                'value' => $row['kKategorie'],
-                'text' => $row['cName'],
-                'description' => $row['cBeschreibung'],
-                'parent' => $row['kOberKategorie'],
-                'sort' => $row['nSort']
+
+        $sql = <<<'SQL'
+            SELECT k.kKategorie,
+                   k.cName,
+                   k.cBeschreibung,
+                   k.nSort,
+                   k.kOberKategorie
+              FROM tkategorie k
+              INNER JOIN tkategorieartikel ka ON k.kKategorie = ka.kKategorie
+              INNER JOIN tartikel a ON ka.kArtikel = a.kArtikel
+             WHERE k.nAktiv = 1
+               AND a.nAktiv = 1
+          GROUP BY k.kKategorie, k.cName, k.cBeschreibung, k.nSort, k.kOberKategorie
+          ORDER BY k.nSort ASC, k.cName ASC
+        SQL;
+
+        $rows = $this->fetchAll($sql);
+        $categories = array_map(static function (array $row): array {
+            return [
+                'value' => (int) $row['kKategorie'],
+                'text' => (string) $row['cName'],
+                'description' => $row['cBeschreibung'] ?? '',
+                'parent' => isset($row['kOberKategorie']) ? (int) $row['kOberKategorie'] : null,
+                'sort' => isset($row['nSort']) ? (int) $row['nSort'] : 0,
             ];
-        }
-        
-        $this->cache->set($cacheKey, $categories, 3600);
+        }, $rows);
+
+        $this->cache->set($cacheKey, $categories, [self::CACHE_TAG], $this->getCacheLifetime());
+
         return $categories;
     }
-    
+
     /**
-     * Get plugin configuration
-     * 
      * @param string $key
      * @param mixed $default
      * @return mixed
      */
     public function getConfig(string $key, $default = null)
     {
-        if (!isset(self::$configCache[$key])) {
-            $sql = "SELECT cValue FROM tplugin_vehicle_search_config WHERE cName = :key";
-            $result = $this->db->executeQuery($sql, ['key' => $key]);
-            $row = $result->fetch();
-            self::$configCache[$key] = $row ? $row['cValue'] : $default;
+        if (!array_key_exists($key, $this->configCache)) {
+            $sql = 'SELECT cValue FROM tplugin_vehicle_search_config WHERE cName = :key LIMIT 1';
+            $rows = $this->fetchAll($sql, ['key' => $key]);
+            $this->configCache[$key] = $rows[0]['cValue'] ?? $default;
         }
-        
-        return self::$configCache[$key];
+
+        return $this->configCache[$key];
     }
-    
-    /**
-     * Set plugin configuration
-     * 
-     * @param string $key
-     * @param mixed $value
-     * @return void
-     */
+
     public function setConfig(string $key, $value): void
     {
-        $sql = "INSERT INTO tplugin_vehicle_search_config (cName, cValue) 
-                VALUES (:key, :value) 
-                ON DUPLICATE KEY UPDATE cValue = :value";
-        
-        $this->db->executeQuery($sql, ['key' => $key, 'value' => $value]);
-        self::$configCache[$key] = $value;
+        $sql = <<<'SQL'
+            INSERT INTO tplugin_vehicle_search_config (cName, cValue)
+                 VALUES (:key, :value)
+            ON DUPLICATE KEY UPDATE cValue = VALUES(cValue)
+        SQL;
+
+        $this->executeStatement($sql, ['key' => $key, 'value' => (string) $value]);
+        $this->configCache[$key] = $value;
     }
-    
+
     /**
-     * Log search statistics
-     * 
-     * @param array $searchData
-     * @return void
+     * @param array<string, mixed> $searchData
      */
     public function logSearchStats(array $searchData): void
     {
-        $sql = "INSERT INTO tplugin_vehicle_search_stats 
-                (cSearchType, cManufacturer, cModel, cVehicleType, kKategorie, nResults, cIP, cUserAgent) 
-                VALUES (:searchType, :manufacturer, :model, :vehicleType, :category, :results, :ip, :userAgent)";
-        
-        $this->db->executeQuery($sql, [
+        $sql = <<<'SQL'
+            INSERT INTO tplugin_vehicle_search_stats
+                (cSearchType, cManufacturer, cModel, cVehicleType, kKategorie, nResults, cIP, cUserAgent)
+            VALUES (:searchType, :manufacturer, :model, :vehicleType, :category, :results, :ip, :userAgent)
+        SQL;
+
+        $this->executeStatement($sql, [
             'searchType' => $searchData['searchType'] ?? '',
             'manufacturer' => $searchData['manufacturer'] ?? null,
             'model' => $searchData['model'] ?? null,
             'vehicleType' => $searchData['vehicleType'] ?? null,
             'category' => $searchData['category'] ?? null,
-            'results' => $searchData['results'] ?? 0,
-            'ip' => $_SERVER['REMOTE_ADDR'] ?? '',
-            'userAgent' => $_SERVER['HTTP_USER_AGENT'] ?? ''
+            'results' => (int) ($searchData['results'] ?? 0),
+            'ip' => $this->getClientIp(),
+            'userAgent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
         ]);
     }
-    
+
     /**
-     * Get search statistics
-     * 
-     * @param int $limit
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     public function getSearchStats(int $limit = 100): array
     {
-        $sql = "SELECT cSearchType, cManufacturer, cModel, cVehicleType, nResults, dSearched
-                FROM tplugin_vehicle_search_stats 
-                ORDER BY dSearched DESC 
-                LIMIT :limit";
-        
-        $result = $this->db->executeQuery($sql, ['limit' => $limit]);
-        $stats = [];
-        
-        while ($row = $result->fetch()) {
-            $stats[] = $row;
-        }
-        
-        return $stats;
+        $limit = max(1, $limit);
+        $sql = <<<'SQL'
+            SELECT cSearchType,
+                   cManufacturer,
+                   cModel,
+                   cVehicleType,
+                   nResults,
+                   dSearched
+              FROM tplugin_vehicle_search_stats
+          ORDER BY dSearched DESC
+             LIMIT :limit
+        SQL;
+
+        return $this->fetchAll($sql, ['limit' => ['value' => $limit, 'type' => PDO::PARAM_INT]]);
     }
-    
-    /**
-     * Clear cache
-     * 
-     * @return void
-     */
+
     public function clearCache(): void
     {
-        $this->cache->flush();
-        
-        // Clear plugin-specific cache
-        $sql = "DELETE FROM tplugin_vehicle_search_cache WHERE dExpires < NOW()";
-        $this->db->executeQuery($sql);
+        if (method_exists($this->cache, 'flushTags')) {
+            $this->cache->flushTags([self::CACHE_TAG]);
+        }
+
+        $sql = 'DELETE FROM tplugin_vehicle_search_cache WHERE dExpires < NOW()';
+        $this->executeStatement($sql);
     }
-    
-    /**
-     * Get plugin instance
-     * 
-     * @return PluginInterface
-     */
+
     public function getPlugin(): PluginInterface
     {
         return $this->plugin;
     }
+
+    private function cacheKey(string $suffix): string
+    {
+        return sprintf('%s_%s', self::PLUGIN_ID, $suffix);
+    }
+
+    private function getCacheLifetime(int $fallback = 3600): int
+    {
+        $configured = (int) $this->getConfig('cache_duration', $fallback);
+
+        return $configured > 0 ? $configured : $fallback;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function fetchAll(string $sql, array $params = []): array
+    {
+        $statement = $this->prepare($sql, $params);
+        $statement->execute();
+
+        return $statement->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function executeStatement(string $sql, array $params = []): void
+    {
+        $statement = $this->prepare($sql, $params);
+        $statement->execute();
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function prepare(string $sql, array $params): PDOStatement
+    {
+        $statement = $this->db->getPDO()->prepare($sql);
+        foreach ($params as $key => $value) {
+            $parameter = str_starts_with((string) $key, ':') ? (string) $key : ':' . $key;
+            $type = PDO::PARAM_STR;
+            $finalValue = $value;
+
+            if (is_array($value) && array_key_exists('value', $value)) {
+                $finalValue = $value['value'];
+                $type = $value['type'] ?? (is_int($finalValue) ? PDO::PARAM_INT : PDO::PARAM_STR);
+            } elseif (is_int($value)) {
+                $type = PDO::PARAM_INT;
+            } elseif ($value === null) {
+                $type = PDO::PARAM_NULL;
+            }
+
+            $statement->bindValue($parameter, $finalValue, $type);
+        }
+
+        return $statement;
+    }
+
+    private function getClientIp(): string
+    {
+        $keys = ['HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR'];
+        foreach ($keys as $key) {
+            $value = $_SERVER[$key] ?? '';
+            if (is_string($value) && $value !== '') {
+                $ip = explode(',', $value)[0];
+
+                return trim($ip);
+            }
+        }
+
+        return '';
+    }
 }
+


### PR DESCRIPTION
## Summary
- declare explicit JTL Shop and PHP compatibility requirements in the plugin manifest
- refactor the service layer and AJAX endpoint to use container services, prepared statements, and plugin-scoped CSRF handling
- modernize admin settings UI and hook scripts to load assets safely and expose configuration via secure tokens

## Testing
- php -l src/VehicleSearchPlugin.php
- php -l frontend/ajax.php
- php -l frontend/hooks/header.php
- php -l frontend/hooks/footer.php
- php -l adminmenu/vehicle_search_settings.php

------
https://chatgpt.com/codex/tasks/task_e_68de4306c630832da6c4d2feeb035d69