### PR TITLE
Handle VehicleSearchPlugin CSRF token from global config

### DIFF
--- a/VehicleSearchPlugin/frontend/templates/vehicle_search.tpl
+++ b/VehicleSearchPlugin/frontend/templates/vehicle_search.tpl
@@ -240,8 +240,17 @@ document.addEventListener('DOMContentLoaded', function() {
     const searchResults = document.getElementById('searchResults');
     const resultsContainer = document.getElementById('resultsContainer');
 
-    // CSRF Token
-    const csrfToken = document.querySelector('input[name="csrf_token"]').value;
+    // Plugin configuration & CSRF token
+    const pluginConfig = window.VehicleSearchPlugin || {};
+    const csrfToken = typeof pluginConfig.csrfToken === 'string' && pluginConfig.csrfToken.length > 0
+        ? pluginConfig.csrfToken
+        : null;
+
+    if (!csrfToken) {
+        console.error('VehicleSearchPlugin configuration missing or invalid.');
+        alert('Güvenlik doğrulama jetonu yüklenemedi. Lütfen sayfayı yenileyin veya destek ile iletişime geçin.');
+        return;
+    }
 
     // Initialize
     loadManufacturers();


### PR DESCRIPTION
## Summary
- read the VehicleSearchPlugin CSRF token from the global configuration injected by the footer hook
- block the inline script and alert the user when the plugin configuration or token is missing so AJAX calls do not run unsecured

## Testing
- not run (JTL Shop runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de7ca3b16c832d9ae245fd28072717