### PR TITLE
Fix admin menu tag casing in info.xml

### DIFF
--- a/VehicleSearchPlugin/info.xml
+++ b/VehicleSearchPlugin/info.xml
@@ -26,13 +26,13 @@
             <File>Migrations/001_create_vehicle_search_tables.php</File>
         </Migration>
         
-        <AdminMenu>
-            <CustomLink>
+        <Adminmenu>
+            <Customlink>
                 <Name>Vehicle Search Settings</Name>
                 <Filename>adminmenu/vehicle_search_settings.php</Filename>
                 <Description>Configure vehicle search settings</Description>
-            </CustomLink>
-        </AdminMenu>
+            </Customlink>
+        </Adminmenu>
         
         <Frontend>
             <Hook>


### PR DESCRIPTION
## Summary
- adjust Adminmenu and Customlink tags in info.xml to match expected casing for JTL Shop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de80c9948c832da884274ce2c68f53