### PR TITLE
Fix namespace mapping for VehicleSearchPlugin service class

### DIFF
--- a/VehicleSearchPlugin/adminmenu/vehicle_search_settings.php
+++ b/VehicleSearchPlugin/adminmenu/vehicle_search_settings.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Plugin\VehicleSearchPlugin\Src\VehicleSearchPlugin;
+use Plugin\VehicleSearchPlugin\VehicleSearchPlugin;
 use JTL\Shop;
 
 require_once PFAD_ROOT . 'admin/includes/admininclude.php';

--- a/VehicleSearchPlugin/frontend/ajax.php
+++ b/VehicleSearchPlugin/frontend/ajax.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use JTL\Shop;
-use Plugin\VehicleSearchPlugin\Src\VehicleSearchPlugin;
+use Plugin\VehicleSearchPlugin\VehicleSearchPlugin;
 
 require_once PFAD_ROOT . 'includes/globalinclude.php';
 

--- a/VehicleSearchPlugin/src/VehicleSearchPlugin.php
+++ b/VehicleSearchPlugin/src/VehicleSearchPlugin.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Plugin\VehicleSearchPlugin\Src;
+namespace Plugin\VehicleSearchPlugin;
 
 use JTL\Cache\JTLCacheInterface;
 use JTL\Plugin\PluginInterface;


### PR DESCRIPTION
## Summary
- align the VehicleSearchPlugin service namespace with the plugin autoloader expectations
- adjust admin and AJAX entry points to import the corrected class name

## Testing
- find VehicleSearchPlugin -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68e2acb5b790832d8ef6b25256e79571